### PR TITLE
Instructions for Mac OSX 10.9

### DIFF
--- a/osx10.9/install.txt
+++ b/osx10.9/install.txt
@@ -1,0 +1,77 @@
+Install instructions for OSX 10.9 (Mavericks)
+=============================================
+
+1) Install Xcode (available from Mac App Store) or the Xcode commandline tools (available from https://developer.apple.com/resources/). If you install Xcode ensure you have also installed the commandline tools by running 'xcode-select --install'.
+
+2) Install homebrew package manager (http://mxcl.github.com/homebrew/):
+ruby -e "$(curl -fsSkL raw.github.com/mxcl/homebrew/go)"
+brew doctor
+brew update
+
+3) Install non-python dependencies (and pil) via homebrew:
+brew install git gfortran python geos graphviz hdf5 jasper netcdf pil proj udunits
+
+4) Create a python virtual environment (these instructions use the name 'scitools'):
+curl -O -L https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.11.5.tar.gz
+tar -zxvf virtualenv-1.11.5.tar.gz
+python virtualenv-1.11.5/virtualenv.py scitools
+
+5) Activate the new virtual environment (all that follows must be done in the activated virtual environment):
+source scitools/bin/activate
+
+6) Install python dependencies into the new virtual environment:
+pip install nose cython pyshp shapely pep8 mock pyke sphinx
+pip install numpy
+pip install netCDF4
+pip install scipy
+pip install matplotlib
+pip install owslib
+pip install biggus
+
+7) Install GRIB API (optional):
+
+i) Download and unpack:
+curl -O -L https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.12.0.tar.gz
+tar -xvf grib_api-1.12.0.tar.gz
+cd grib_api-1.12.0
+
+ii) Create a link to python-config in the virtual environment:
+ln -s /usr/local/bin/python-config ~/scitools/bin
+
+iii) Build and install to virtual environment:
+./configure --prefix=$HOME/scitools --enable-python --with-jasper=/usr/local
+make
+make install
+cd ..
+
+iv) Add .pth file to virtualenv's site-packages so that 'import gribapi' works:
+echo grib_api > ~/scitools/lib/python2.7/site-packages/gribapi.pth
+
+8) Install PP packing library (optional):
+
+i) Download and unpack:
+curl -O -L https://puma.nerc.ac.uk/trac/UM_TOOLS/raw-attachment/wiki/unpack/unpack-160114.tgz
+tar -zxvf unpack-160114.tgz
+cd unpack-160114
+
+ii) Apply patch for building:
+patch -p1 < ../unpack-160114_osx10.9.patch
+
+ii) Build and install into virtual environment:
+cd libmo_unpack
+./make_library
+./distribute.sh ~/scitools
+cd ../..
+
+9) Install Cartopy:
+git clone https://github.com/SciTools/cartopy.git
+cd cartopy
+python setup.py install
+cd ..
+
+10) Install Iris:
+git clone https://github.com/SciTools/iris.git
+cd iris
+python setup.py --with-unpack build_ext -I$HOME/scitools/include -L$HOME/scitools/lib install
+cd ..
+

--- a/osx10.9/unpack-160114_osx10.9.patch
+++ b/osx10.9/unpack-160114_osx10.9.patch
@@ -1,0 +1,34 @@
+diff -rupN unpack-160114-orig/libmo_unpack/distribute.sh unpack-160114/libmo_unpack/distribute.sh
+--- unpack-160114-orig/libmo_unpack/distribute.sh	2014-01-08 11:03:27.000000000 +0000
++++ unpack-160114/libmo_unpack/distribute.sh	2014-05-06 16:53:28.000000000 +0100
+@@ -43,8 +43,14 @@ then
+   exit 1
+ fi
+ 
+-cp -d lib/lib* $synch_dir/lib
+-cp -d include/*.h $synch_dir/include
++cp -a lib/lib* $synch_dir/lib
++cp -a include/*.h $synch_dir/include
++
++# Modify install_name on OSX.
++for x in lib/lib*.so*; do
++    install_name_tool -id ${synch_dir%/}/$x ${synch_dir%/}/$x
++done
++
+ 
+ if [ $? -ne 0 ]
+ then
+diff -rupN unpack-160114-orig/libmo_unpack/make_library unpack-160114/libmo_unpack/make_library
+--- unpack-160114-orig/libmo_unpack/make_library	2014-01-08 11:03:27.000000000 +0000
++++ unpack-160114/libmo_unpack/make_library	2014-05-06 16:53:38.000000000 +0100
+@@ -59,8 +59,8 @@ then
+   has_shared=1
+ elif [ "_$os" == "_Darwin" ]
+ then
+-  CC=gcc
+-  LD="ld -shared -soname libmo_unpack.so.$major"
++  CC=cc
++  LD="ld -dylib -undefined dynamic_lookup -install_name @rpath/libmo_unpack.so.$major"
+   AR="ar"
+   OPTS="-O4 -I include -D_LARGEFILE_SOURCE -D_LARGEFILE_SOURCE64 -D_FILE_OFFSET_BITS=64 -D_DARWIN_SOURCE"
+   has_shared=1


### PR DESCRIPTION
This adds instructions for installing Iris (incl. Cartopy and Biggus) onto Mac OSX 10.9. By its nature of using homebrew and pip a lot of the packages are very recent versions so I also bumped PP packing and the GRIB API to the latest versions.
